### PR TITLE
Suggest a more pythonic implementation of the directional-data validation

### DIFF
--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -97,7 +97,7 @@ def validate(df):
         df = IamDataFrame(df)
     success = True
 
-    # set up list of dimension (columns) to validate
+    # set up list of dimension (columns) to validate (`subannual` is optional)
     cols = [
         ('region', regions, 's'),
         ('variable', variables, 's')
@@ -124,5 +124,5 @@ def validate(df):
 
 def _validate_directional(x):
     """Utility function to check whether region-to-region code is valid"""
-    x = x.split(">")
+    x = x.split('>')
     return len(x) == 2 and all([i in regions for i in x])

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -109,13 +109,20 @@ def validate(df):
     msg = 'The following {} are not defined in the nomenclature:\n    {}'
     for col, codelist, ext in cols:
         invalid = [c for c in df.data[col].unique() if c not in codelist]
-        # Check the entries in the invalid list related to directional data
-        for i in reversed(invalid):
-            if ">" in i:
-                sp = i.split(">")
-                if sp[0] in codelist and sp[1] in codelist:
-                    invalid.remove(i)
+
+        # check the entries in the invalid list related to directional data
+        if col == 'region':
+            invalid = [i for i in invalid if not _validate_directional(i)]
+
+        # check if any entries in the column are invalid and write to log
         if invalid:
             success = False
             logger.warning(msg.format(col + ext, invalid))
+
     return success
+
+
+def _validate_directional(x):
+    """Utility function to check whether region-to-region code is valid"""
+    x = x.split(">")
+    return len(x) == 2 and all([i in regions for i in x])

--- a/nomenclature/tests/test_validate.py
+++ b/nomenclature/tests/test_validate.py
@@ -28,3 +28,6 @@ def test_validate_directional():
     # test that validation works as expected with directional data
     assert validate(df.rename(region={'Europe': 'Austria>Germany'}))
     assert not validate(df.rename(region={'Europe': 'Austria>foo'}))
+
+    # test that directional data with more than one `>` fails
+    assert not validate(df.rename(region={'Europe': 'Austria>Italy>France'}))


### PR DESCRIPTION
and adding a test guarding against having multiple `>` in the region column