### PR TITLE
Refactor the implementation of the datetime-validation

### DIFF
--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -115,15 +115,28 @@ def validate(df):
     for col, codelist, ext in cols:
         invalid = [c for c in df.data[col].unique() if c not in codelist]
 
-        # check the entries in the invalid list related to directional data
-        if col == 'region':
+        # check if entries in the invalid list are related to directional data
+        if col == 'region' and invalid:
             invalid = [i for i in invalid if not _validate_directional(i)]
 
-        if col == 'subannual':
-            invalid = [c for c in df.data[col] if not _get_timestamp_for_subannual(c, year)]
+        # check if entries in the invalid list for subannual are datetime
+        if col == 'subannual' and invalid:
 
-        if col == 'time':
-            invalid = [c for c in df.data[col] if not _validate_time_column(c)]
+            # downselect to any data that might be invalid
+            data = df.filter(subannual=invalid)\
+                .data[['year', 'subannual']].drop_duplicates()
+
+            # call utility whether subannual can be cast to datetime
+            valid_dt, invalid_tz, invalid = _validate_subannual_dt(
+                list(zip(data['year'], data['subannual']))
+            )
+
+            # verify that all datetime-instances have the correct timezone
+            if invalid_tz or \
+                    any([t.tzname() != 'UTC+01:00' for t in valid_dt]):
+                success = False
+                logger.warning('Time is not given in Central European time'
+                               ' (UTC+01:00)!')
 
         # check if any entries in the column are invalid and write to log
         if invalid:
@@ -138,37 +151,17 @@ def _validate_directional(x):
     x = x.split('>')
     return len(x) == 2 and all([i in regions for i in x])
 
-def _get_timestamp_for_subannual(a, year):
-    try:
-        month = a[0:2]
-        a = a.split('-')[1]
-        day = a[0:2]
-        if 'T' in a:
-            timestamp = a.split('T')[1].split('+')[0]
-            hour = timestamp.split(':')[0]
-            minute = timestamp.split(':')[1]
-            second = 0
-            if timestamp.count(':') == 2:
-                second = timestamp.split(':')[2]
-        else:
-            hour = minute = second = 0
 
-        if '+' + a.split('+')[1] == '+01:00':
-            ts = datetime(int(year), int(month), int(day), int(hour),
-                          int(minute), int(second))
-            return isinstance(ts, datetime)
-        else:
-            return False
-    except Exception:
-        return False
-
-def _validate_time_column(timestamp):
-    strings = timestamp.split('+')
-    if strings[1] == '01:00':
-        try:
-            return isinstance(datetime.strptime(strings[0], '%Y-%m-%dT%H:%M'), datetime)
-        except Exception:
-            return False
-    else:
-        return False
-
+def _validate_subannual_dt(x):
+    """Utility function to separate and validate datetime format"""
+    valid_dt, invalid_tz, invalid = [], False, set()
+    for (y, s) in x:
+        try:  # casting to Central European datetime
+            valid_dt.append(datetime.strptime(f'{y}-{s}', '%Y-%m-%dT%H:%M%z'))
+        except ValueError:
+            try:  # casting to UTC datetime
+                datetime.strptime(f'{y}-{s}', '%Y-%m-%dT%H:%M')
+                invalid_tz = True
+            except ValueError:  # if casting to datetime fails, return invalid
+                invalid.add(s)
+    return valid_dt, invalid_tz, list(invalid)

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -106,13 +106,9 @@ def validate(df):
 
     # add 'subannual' (wide format) or 'time' (long format) to list to validate
     if 'subannual' in df.data.columns:
-        cols.append(('subannual', 'True', ' timeslices'))
-        # get (one) year from columns to validate datetime
-        year = df.data.year[0]
+        cols.append(('subannual', subannual, ' timeslices'))
     elif 'time' in df.data.columns:
         cols.append(('time', 'True', 'timeslices'))
-
-
 
     # iterate over dimensions and perform validation
     msg = 'The following {} are not defined in the nomenclature:\n    {}'

--- a/nomenclature/tests/test_validate.py
+++ b/nomenclature/tests/test_validate.py
@@ -35,6 +35,13 @@ def test_validate_directional():
     assert not validate(df.rename(region={'Europe': 'Austria>Italy>France'}))
 
 
+def test_validate_subannual_months():
+    # test that validation works as expected with months
+    # (and representative timeslices generally)
+    assert validate(IamDataFrame(TEST_DF, subannual='January'))
+    assert not validate(IamDataFrame(TEST_DF, subannual='foo'))
+
+
 def test_validate_subannual():
     # test that validation works as expected with sub-annual column (wide format)
     assert validate(df2)

--- a/nomenclature/tests/test_validate.py
+++ b/nomenclature/tests/test_validate.py
@@ -9,11 +9,6 @@ TEST_DF = pd.DataFrame([
     columns=['model', 'scenario', 'region', 'variable', 'unit', 2005, 2010])
 df = IamDataFrame(TEST_DF)
 
-TEST_DF2 = pd.DataFrame(['01-01T00:00+01:00'], columns=['subannual'])
-TEST_DF3 = pd.DataFrame(['2020-01-01T00:00+01:00'], columns=['time'])
-df2 = IamDataFrame(TEST_DF.join(TEST_DF2))
-df3 = IamDataFrame(TEST_DF.join(TEST_DF3))
-
 
 def test_validate():
     # test simple validation

--- a/nomenclature/tests/test_validate.py
+++ b/nomenclature/tests/test_validate.py
@@ -42,18 +42,15 @@ def test_validate_subannual_months():
     assert not validate(IamDataFrame(TEST_DF, subannual='foo'))
 
 
-def test_validate_subannual():
-    # test that validation works as expected with sub-annual column (wide format)
-    assert validate(df2)
-    assert not validate(df2.rename(subannual={'01-01T00:00+01:00' : '01-01T00:00+02:00'}))
-    assert not validate(df2.rename(subannual={'01-01T00:00+01:00':'20-01T00:00:10+01:00'}))
-    assert validate(df2.rename(subannual={'01-01T00:00+01:00': '12-01T00:00:10+01:00'}))
+def test_validate_subannual_utc():
+    # test that validation works as expected with continuous time as subannual
+    assert validate(IamDataFrame(TEST_DF, subannual='01-01T00:00+01:00'))
 
+    # assert that missing timezone fails
+    assert not validate(IamDataFrame(TEST_DF, subannual='01-01T00:00'))
 
-def test_validate_time():
-    # test that validation works as expected with 'time' column (long format)
-    assert validate(df3)
-    assert not validate(df3.rename(time={'2020-01-01T00:00+01:00' : '2020-01-01T00:00+02:00'}))
-    assert not validate(df3.rename(time={'2020-01-01T00:00+01:00' : '0-01-01T00:00+01:00'}))
+    # assert that wrong timezone fails
+    assert not validate(IamDataFrame(TEST_DF, subannual='01-01T00:00+02:00'))
 
-
+    # assert that value not castable to datetime fails
+    assert not validate(IamDataFrame(TEST_DF, subannual='01-32T00:00+01:00'))

--- a/nomenclature/tests/test_validate.py
+++ b/nomenclature/tests/test_validate.py
@@ -37,7 +37,7 @@ def test_validate_subannual_months():
     assert not validate(IamDataFrame(TEST_DF, subannual='foo'))
 
 
-def test_validate_subannual_utc():
+def test_validate_subannual_datetime_as_subannual():
     # test that validation works as expected with continuous time as subannual
     assert validate(IamDataFrame(TEST_DF, subannual='01-01T00:00+01:00'))
 


### PR DESCRIPTION
Thank you @sebastianzwickl for making a first stab to implement the datetime-validation in the nomenclature!

A few issues:

1. the extended implementation breaks the validation with the representative-timeslice approach. This is entirely my fault because there were no tests for it - so I added a test using the months-list.

2. the new implementation re-invents the casting of a suitable string to datetime - this can be a lot easier using `datetime.strptime(<string>, '%Y-%m-%dT%H:%M%z'))` within a try-except statement.

3. I added checks that the timezone is in line with the convention (and tests for it).

4. I removed the additional test dataframes, because these can be set much easier as a kwarg when initializing the `IamDataFrame`.

5. The changes I made are already quite substantial, so I simply removed the validation for an `IamDataFrame` with a time column (instead of year+subannual).