### PR TITLE
Alternative implementation of swapping time for year + subannual

### DIFF
--- a/nomenclature/tests/test_transform_functionality.py
+++ b/nomenclature/tests/test_transform_functionality.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from pyam import IamDataFrame
-from nomenclature import time_to_year_subannual
+from nomenclature import swap_time_for_subannual
 
 
 TEST_DF = pd.DataFrame([
@@ -12,10 +12,10 @@ TEST_DF = pd.DataFrame([
 df = IamDataFrame(TEST_DF)
 
 
-def test_transformation_IamDataFrame():
-    # test transformation (cast) from IamDataFrame
-    to_test = time_to_year_subannual(df).as_pandas()
-    assert (to_test['year'][0]==2015 and to_test['subannual'][0]=='01-01 00:00:00+01:00')
+def test_swap_time_for_subannual():
+    # test transforming of IamDataFrame in datetime domain to year + subannual
+    obs = swap_time_for_subannual(df)
+    assert (obs['year'][0] == 2015 and obs['subannual'][0] == '01-01T00:00+0100')
 
 
 

--- a/nomenclature/tests/test_transform_functionality.py
+++ b/nomenclature/tests/test_transform_functionality.py
@@ -4,18 +4,17 @@ from nomenclature import swap_time_for_subannual
 
 
 TEST_DF = pd.DataFrame([
-    ['model_a', 'scen_a', 'Europe', 'Primary Energy', 'EJ/yr', 
-     '2015-01-01T00:00:00+01:00', 11231.088],
+    ['model_a', 'scen_a', 'Europe', 'Primary Energy', 'EJ/yr', 1, 6.],
 ],
-    columns=['model', 'scenario', 'region', 
-             'variable', 'unit', 'time', 'value'])
+    columns=['model', 'scenario', 'region', 'variable', 'unit',
+             '2005-06-17T00:00+0100', '2010-07-21T12:00+0100'])
 df = IamDataFrame(TEST_DF)
 
 
 def test_swap_time_for_subannual():
     # test transforming of IamDataFrame in datetime domain to year + subannual
-    obs = swap_time_for_subannual(df)
-    assert (obs['year'][0] == 2015 and obs['subannual'][0] == '01-01T00:00+0100')
-
-
-
+    obs = swap_time_for_subannual(df).data
+    obs_year = list(obs['year'].values)
+    obs_subannual = list(obs['subannual'].values)
+    assert obs_year == [2005, 2010] and \
+        obs_subannual == ['06-17T00:00+0100', '2010-07-21T12:00+0100']


### PR DESCRIPTION
This PR proposes a more pythonic implementation of the feature to swap a `datetime` domain for two index columns `year` and `subannual`. The test is also adapted to use an IamDataFrame that is as close as possible to the test data used in the main test file (which usually makes it easier for new users to understand what's going on).