### PR TITLE
Refactor `_validate_time_dt` and move timezone check to own subfunction

### DIFF
--- a/nomenclature/tests/test_castable_functionality.py
+++ b/nomenclature/tests/test_castable_functionality.py
@@ -13,8 +13,7 @@ df = IamDataFrame(TEST_DF)
 
 
 def test_validate_time_dt():
-    valid, bool, invalid = _validate_time_dt(df.data.time)
-    assert bool == True
+    assert _validate_time_dt(df.data.time)
 
 
 def test_validate_time_entry():


### PR DESCRIPTION
This PR simplifies the `_validate_time_dt` function and moves the timezone check to own sub function (so that it be later re-used for the the `_validate_subannual` function). It is not necessary to actually return three different variables from the sub function (compared to the subannual-validation.